### PR TITLE
Add test coverage across codon alignment, CLI, and PAF helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 import types
 from collections.abc import Generator, Iterable, Iterator
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from typing import Any, Callable, TextIO
 
 import pytest
@@ -133,10 +133,10 @@ def pafpy_shim() -> Generator[None, None, None]:
 
 @pytest.fixture(autouse=True)
 def rich_shim() -> Generator[None, None, None]:
-    """Provide a minimal :mod:`rich` shim with ``print``."""
-    fake_rich = types.ModuleType("rich")
-    fake_rich.print = print  # type: ignore[attr-defined]
-    with patch.dict(sys.modules, {"rich": fake_rich}):
+    """Mock :mod:`rich`'s ``print`` while keeping the real package."""
+    import rich
+
+    with patch.object(rich, "print", MagicMock(side_effect=print)):
         yield
 
 

--- a/tests/test_blosum62.py
+++ b/tests/test_blosum62.py
@@ -46,3 +46,17 @@ def test_blosum62_empty_sequences() -> None:
     from postalign.utils.blosum62 import blosum62_score
 
     assert blosum62_score(b"", b"") == 0
+
+
+def test_blosum62_mismatched_lengths() -> None:
+    """Extra residues in one sequence should be ignored in scoring."""
+    from postalign.utils.blosum62 import blosum62_score
+
+    assert blosum62_score(b"AAA", b"A") == 4
+
+
+def test_blosum62_lowercase_ignored() -> None:
+    """Lowercase amino acids should be treated as unknown and score zero."""
+    from postalign.utils.blosum62 import blosum62_score
+
+    assert blosum62_score(b"a", b"a") == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import pytest
 import typer
+import sys
+from types import ModuleType
 from typing import Callable
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+_rich_stub = ModuleType("rich")
+_rich_stub.print = print  # type: ignore[attr-defined]
+sys.modules.setdefault("rich", _rich_stub)
 
 
 def _noop_result_callback(
@@ -176,3 +182,87 @@ def test_reference_callback_requires_file_for_non_msa() -> None:
         typer.BadParameter
     ):
         reference_callback(ctx, param, "ref.fa")
+
+
+def test_seqs_prior_alignment_callback_missing_name() -> None:
+    """Missing parameter name should raise :class:`BadParameter`."""
+
+    with patch.object(
+        typer.Typer,
+        "result_callback",
+        _noop_result_callback,
+        create=True,
+    ):
+        from postalign.cli import (
+            AlignmentFormat,
+            seqs_prior_alignment_callback,
+        )
+
+    ctx = MagicMock()
+    ctx.params = {"alignment_format": AlignmentFormat.PAF}
+    param = MagicMock()
+    param.name = None
+    with pytest.raises(typer.BadParameter):
+        seqs_prior_alignment_callback(ctx, param, StringIO())
+
+
+def test_seqs_prior_alignment_callback_passes_through_for_paf() -> None:
+    """PAF format should return the provided handle."""
+
+    with patch.object(
+        typer.Typer,
+        "result_callback",
+        _noop_result_callback,
+        create=True,
+    ):
+        from postalign.cli import (
+            AlignmentFormat,
+            seqs_prior_alignment_callback,
+        )
+
+    ctx = MagicMock()
+    ctx.params = {"alignment_format": AlignmentFormat.PAF}
+    param = MagicMock()
+    param.name = "seqs_prior_alignment"
+    handle = StringIO()
+    result = seqs_prior_alignment_callback(ctx, param, handle)
+    assert result is handle
+
+
+def test_process_pipeline_requires_nucleotides() -> None:
+    """Pipeline should reject amino acid sequences."""
+
+    with patch.object(
+        typer.Typer,
+        "result_callback",
+        _noop_result_callback,
+        create=True,
+    ):
+        from collections.abc import Iterable
+        from postalign.cli import process_pipeline, AlignmentFormat
+        from postalign.processor import Processor
+        from postalign.models import Message
+        from postalign.models.sequence import RefSeqPair
+
+    def dummy_proc(
+        iterator: Iterable[RefSeqPair],
+        messages: list[Message],
+    ) -> list[str]:
+        return ["out"]
+
+    proc = Processor("out", True, dummy_proc)
+    input_alignment = StringIO()
+    output = StringIO()
+    with pytest.raises(typer.BadParameter):
+        process_pipeline(
+            [proc],
+            input_alignment,
+            None,
+            output,
+            AlignmentFormat.MSA,
+            "ref",
+            False,
+            False,
+            False,
+            None,
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-import pytest
-import typer
-import sys
-from types import ModuleType
-from typing import Callable
 from io import StringIO
 from pathlib import Path
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
-_rich_stub = ModuleType("rich")
-_rich_stub.print = print  # type: ignore[attr-defined]
-sys.modules.setdefault("rich", _rich_stub)
+import pytest
+import typer
 
 
 def _noop_result_callback(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,31 @@ def test_seqs_prior_alignment_callback_passes_through_for_paf() -> None:
     assert result is handle
 
 
+def test_seqs_prior_alignment_callback_warns_for_msa() -> None:
+    """Providing sequences for MSA format should warn and return ``None``."""
+
+    with patch.object(
+        typer.Typer,
+        "result_callback",
+        _noop_result_callback,
+        create=True,
+    ):
+        from postalign.cli import (
+            AlignmentFormat,
+            seqs_prior_alignment_callback,
+        )
+
+    ctx = MagicMock()
+    ctx.params = {"alignment_format": AlignmentFormat.MSA}
+    param = MagicMock()
+    param.name = "seqs_prior_alignment"
+    handle = StringIO()
+    with patch("sys.stderr", new_callable=StringIO) as err:
+        result = seqs_prior_alignment_callback(ctx, param, handle)
+    assert result is None
+    assert "ignore -p/--seqs-prior-alignment" in err.getvalue()
+
+
 def test_process_pipeline_requires_nucleotides() -> None:
     """Pipeline should reject amino acid sequences."""
 

--- a/tests/test_codon_alignment.py
+++ b/tests/test_codon_alignment.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
 
+from postalign.models import NAPosition
 from postalign.processors.codon_alignment import (
+    LEFT,
     REFGAP,
     SEQGAP,
     codon_alignment,
-    gap_placement_score_callback,
+    codon_pairs_group_key,
+    extend_codons_until_gap,
+    find_best_matches,
+    find_first_gap,
+    move_gaps_to_center,
     parse_gap_placement_score,
+    gap_placement_score_callback,
+    calc_match_score,
+    separate_gaps_from_nas,
+    paired_find_best_matches,
 )
 
 
@@ -112,3 +122,102 @@ def test_remove_redundant_gaps() -> None:
     new_ref, new_seq = remove_redundant_gaps(ref, seq)
     assert NAPosition.as_str(new_ref) == "AB"
     assert NAPosition.as_str(new_seq) == "AB"
+
+
+def test_extend_codons_until_gap_left() -> None:
+    """Scanning backward should stop before codons containing gaps."""
+
+    codon1 = NAPosition.init_from_bytes(b"A-G")
+    codon2 = NAPosition.init_from_bytes(b"ATG")
+    ref_cd, seq_cd, length = extend_codons_until_gap(
+        [codon1, codon2], [codon1, codon2], LEFT
+    )
+    assert length == 1
+    assert [NAPosition.as_str(c) for c in ref_cd] == ["ATG"]
+
+
+def test_find_first_gap_found() -> None:
+    """Sequences with gaps should return the first gap index."""
+
+    nas = NAPosition.init_from_bytes(b"AT-G")
+    assert find_first_gap(nas) == 2
+
+
+def test_calc_match_score() -> None:
+    """Match scoring should include nucleotide and amino-acid contributions."""
+
+    mynas = NAPosition.init_from_bytes(b"ATG")
+    othernas = NAPosition.init_from_bytes(b"ATG")
+    assert calc_match_score(mynas, othernas, 0.0) == pytest.approx(8.0)
+
+
+def test_separate_gaps_from_nas() -> None:
+    """Separating gaps should partition sequences into nongaps and gaps."""
+
+    nas = NAPosition.init_from_bytes(b"A-G")
+    nongaps, gaps = separate_gaps_from_nas(nas)
+    assert NAPosition.as_str(nongaps) == "AG"
+    assert NAPosition.as_str(gaps) == "-"
+
+
+def test_find_best_matches_fallback() -> None:
+    """If no placement improves score, original nucleotides are returned."""
+
+    mynas = NAPosition.init_from_bytes(b"A-")
+    othernas = NAPosition.init_from_bytes(b"A")
+    result = find_best_matches(
+        mynas, othernas, set(), REFGAP, {}, False, False
+    )
+    assert NAPosition.as_str(result) == "A"
+
+
+def test_paired_find_best_matches_refgap() -> None:
+    """REFGAP type should delegate to ``find_best_matches`` with ref NAs."""
+
+    ref = NAPosition.init_from_bytes(b"A-A")
+    seq = NAPosition.init_from_bytes(b"AAA")
+    gps = {REFGAP: {}, SEQGAP: {}}
+    with patch(
+        "postalign.processors.codon_alignment.find_best_matches"
+    ) as fbm:
+        fbm.return_value = ref
+        paired_find_best_matches(ref, seq, REFGAP, gps, False, False)
+        fbm.assert_called_once()
+
+
+def test_paired_find_best_matches_seqgap() -> None:
+    """SEQGAP type should delegate using sequence nucleotides."""
+
+    ref = NAPosition.init_from_bytes(b"AAA")
+    seq = NAPosition.init_from_bytes(b"A-A")
+    gps = {REFGAP: {}, SEQGAP: {}}
+    with patch(
+        "postalign.processors.codon_alignment.find_best_matches"
+    ) as fbm:
+        fbm.return_value = seq
+        paired_find_best_matches(ref, seq, SEQGAP, gps, True, True)
+        fbm.assert_called_once()
+
+
+def test_codon_pairs_group_key() -> None:
+    """Codon pairs should classify gap types correctly."""
+
+    refgap_cd = NAPosition.init_from_bytes(b"A--")
+    seq_cd = NAPosition.init_from_bytes(b"AAA")
+    assert codon_pairs_group_key((0, (refgap_cd, seq_cd))) == REFGAP
+
+    ref_cd2 = NAPosition.init_from_bytes(b"AAA")
+    seqgap_cd = NAPosition.init_from_bytes(b"A--")
+    assert codon_pairs_group_key((0, (ref_cd2, seqgap_cd))) == SEQGAP
+
+    ref_cd3 = NAPosition.init_from_bytes(b"AAA")
+    seq_cd3 = NAPosition.init_from_bytes(b"AAA")
+    assert codon_pairs_group_key((0, (ref_cd3, seq_cd3))) == 0
+
+
+def test_move_gaps_to_center() -> None:
+    """Gaps should be relocated to the center of the sequence."""
+
+    nas = NAPosition.init_from_bytes(b"--AB")
+    centered = move_gaps_to_center(nas)
+    assert NAPosition.as_str(centered) == "A--B"

--- a/tests/test_codon_alignment.py
+++ b/tests/test_codon_alignment.py
@@ -53,3 +53,62 @@ def test_codon_alignment_invalid_ref_end() -> None:
 
     with pytest.raises(typer.BadParameter):
         codon_alignment(ref_start=5, ref_end=6)
+
+
+def test_extend_codons_until_gap_right() -> None:
+    """Scanning forward should stop before codons containing gaps."""
+    from postalign.models import NAPosition
+    from postalign.processors.codon_alignment import (
+        extend_codons_until_gap,
+        RIGHT,
+    )
+
+    codon1 = NAPosition.init_from_bytes(b"ATG")
+    codon2 = NAPosition.init_from_bytes(b"A-G")
+    ref_cd, seq_cd, length = extend_codons_until_gap(
+        [codon1, codon2], [codon1, codon2], RIGHT
+    )
+    assert length == 1
+    assert [NAPosition.as_str(c) for c in ref_cd] == ["ATG"]
+
+
+def test_find_windows_with_gap() -> None:
+    """Gap windows should be separated when distance exceeds threshold."""
+    from postalign.models import NAPosition
+    from postalign.processors.codon_alignment import find_windows_with_gap
+
+    ref = NAPosition.init_from_bytes(b"AAA---BBB---CCC")
+    seq = NAPosition.init_from_bytes(b"AAA---BBB---CCC")
+    windows = find_windows_with_gap(ref, seq, 1)
+    assert windows == [slice(3, 6), slice(9, 12)]
+
+
+def test_find_first_gap_none() -> None:
+    """Sequences without gaps should return ``-1`` for first gap."""
+    from postalign.models import NAPosition
+    from postalign.processors.codon_alignment import find_first_gap
+
+    nas = NAPosition.init_from_bytes(b"ATG")
+    assert find_first_gap(nas) == -1
+
+
+def test_move_gap_to_codon_end() -> None:
+    """Gaps within codons should be shifted to the end."""
+    from postalign.models import NAPosition
+    from postalign.processors.codon_alignment import move_gap_to_codon_end
+
+    codons = [NAPosition.init_from_bytes(b"A-A")]
+    moved = move_gap_to_codon_end(codons)
+    assert [NAPosition.as_str(c) for c in moved] == ["AA-"]
+
+
+def test_remove_redundant_gaps() -> None:
+    """Matched gaps across sequences should be pruned."""
+    from postalign.models import NAPosition
+    from postalign.processors.codon_alignment import remove_redundant_gaps
+
+    ref = NAPosition.init_from_bytes(b"A--B")
+    seq = NAPosition.init_from_bytes(b"A--B")
+    new_ref, new_seq = remove_redundant_gaps(ref, seq)
+    assert NAPosition.as_str(new_ref) == "AB"
+    assert NAPosition.as_str(new_seq) == "AB"

--- a/tests/test_codon_alignment.py
+++ b/tests/test_codon_alignment.py
@@ -1,0 +1,55 @@
+"""Tests for codon alignment utilities."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from postalign.processors.codon_alignment import (
+    REFGAP,
+    SEQGAP,
+    codon_alignment,
+    gap_placement_score_callback,
+    parse_gap_placement_score,
+)
+
+
+def test_parse_gap_placement_score_valid() -> None:
+    """Valid gap placement strings should map to score dictionaries."""
+
+    scores = parse_gap_placement_score("204ins:-5,2041/12del:10")
+    assert scores[REFGAP][(204, 0)] == -5
+    assert scores[SEQGAP][(2041, 12)] == 10
+
+
+def test_parse_gap_placement_score_invalid() -> None:
+    """Invalid score strings should raise :class:`ValueError`."""
+
+    with pytest.raises(ValueError):
+        parse_gap_placement_score("204foo")
+
+
+def test_gap_placement_score_callback_missing_name() -> None:
+    """Missing parameter name should raise :class:`BadParameter`."""
+
+    ctx = MagicMock()
+    param = MagicMock()
+    param.name = None
+    with pytest.raises(typer.BadParameter):
+        gap_placement_score_callback(ctx, param, ())
+
+
+def test_codon_alignment_invalid_ref_start() -> None:
+    """Invalid reference start should raise :class:`BadParameter`."""
+
+    with pytest.raises(typer.BadParameter):
+        codon_alignment(ref_start=0, ref_end=-1)
+
+
+def test_codon_alignment_invalid_ref_end() -> None:
+    """Too-small ref_end should raise :class:`BadParameter`."""
+
+    with pytest.raises(typer.BadParameter):
+        codon_alignment(ref_start=5, ref_end=6)

--- a/tests/test_codonutils.py
+++ b/tests/test_codonutils.py
@@ -47,7 +47,9 @@ def test_translate_codons_translates_chunks() -> None:
 
     nas = NAPosition.init_from_bytes(b"ATGTTT")
 
-    def chunk_list(seq, n):
+    from collections.abc import Iterator
+
+    def chunk_list(seq: list, n: int) -> Iterator[list]:
         for i in range(0, len(seq), n):
             yield list(seq[i:i + n])
 

--- a/tests/test_codonutils.py
+++ b/tests/test_codonutils.py
@@ -39,6 +39,15 @@ def test_translate_codon_frameshift_short() -> None:
     assert translate_codon(nas, fs_as=b"X") == b"X"
 
 
+def test_translate_codon_stop() -> None:
+    """Stop codons should translate to the stop symbol."""
+    from postalign.models import NAPosition
+    from postalign.utils.codonutils import translate_codon
+
+    nas = NAPosition.init_from_bytes(b"TGA")
+    assert translate_codon(nas) == b"*"
+
+
 def test_translate_codons_translates_chunks() -> None:
     """``translate_codons`` should translate each codon chunk."""
     from unittest.mock import patch
@@ -62,6 +71,15 @@ def test_get_codons_returns_expected() -> None:
     from postalign.utils.codonutils import get_codons
 
     assert get_codons(ord(b"M")) == [b"ATG"]
+
+
+def test_get_codons_unknown_raises_key_error() -> None:
+    """Unknown amino acids should raise :class:`KeyError`."""
+    from postalign.utils.codonutils import get_codons
+    import pytest
+
+    with pytest.raises(KeyError):
+        get_codons(ord(b"?"))
 
 
 def test_compare_codon_match_and_mismatch() -> None:

--- a/tests/test_codonutils.py
+++ b/tests/test_codonutils.py
@@ -97,3 +97,19 @@ def test_compare_codon_ambiguous_mismatch() -> None:
     from postalign.utils.codonutils import compare_codon
 
     assert compare_codon(b"ACG", b"ACY") is False
+
+
+def test_translate_codons_frameshift_last_codon() -> None:
+    """Trailing incomplete codons should yield a frameshift marker."""
+    from postalign.models import NAPosition
+    from postalign.utils.codonutils import translate_codons
+
+    nas = NAPosition.init_from_bytes(b"ATGA")
+    assert translate_codons(nas) == [b"M", b"X"]
+
+
+def test_compare_codon_highly_ambiguous() -> None:
+    """Highly ambiguous target bases should return ``False``."""
+    from postalign.utils.codonutils import compare_codon
+
+    assert compare_codon(b"ATG", b"BTG") is False

--- a/tests/test_group_by_codons.py
+++ b/tests/test_group_by_codons.py
@@ -81,3 +81,15 @@ def test_find_codon_trim_slice_all_gaps() -> None:
     ]
     trim_slice = find_codon_trim_slice(codons)
     assert trim_slice == slice(2, 0)
+
+
+def test_group_by_codons_ignores_leading_gaps() -> None:
+    """Leading gaps should not initiate a new codon."""
+    from postalign.models import NAPosition
+    from postalign.utils.group_by_codons import group_by_codons
+
+    ref = NAPosition.init_from_bytes(b"-ATG")
+    seq = NAPosition.init_from_bytes(b"-ATG")
+    ref_codons, seq_codons = group_by_codons(ref, seq)
+    assert [NAPosition.as_str(c) for c in ref_codons] == ["ATG"]
+    assert [NAPosition.as_str(c) for c in seq_codons] == ["ATG"]

--- a/tests/test_group_by_codons.py
+++ b/tests/test_group_by_codons.py
@@ -68,3 +68,16 @@ def test_find_codon_trim_slice_no_trim() -> None:
     ]
     trim_slice = find_codon_trim_slice(codons)
     assert trim_slice == slice(0, 2)
+
+
+def test_find_codon_trim_slice_all_gaps() -> None:
+    """All-gap codons should result in an empty slice."""
+    from postalign.models import NAPosition
+    from postalign.utils.group_by_codons import find_codon_trim_slice
+
+    codons = [
+        NAPosition.init_from_bytes(b"---"),
+        NAPosition.init_from_bytes(b"---"),
+    ]
+    trim_slice = find_codon_trim_slice(codons)
+    assert trim_slice == slice(2, 0)

--- a/tests/test_group_by_codons.py
+++ b/tests/test_group_by_codons.py
@@ -42,3 +42,29 @@ def test_group_by_gene_codons() -> None:
     assert [NAPosition.as_str(c) for c in results[0][1]] == ["ATG"]
     assert results[1][0] == "geneB"
     assert [NAPosition.as_str(c) for c in results[1][1]] == ["AAA"]
+
+
+def test_group_by_gene_codons_multiple_ranges() -> None:
+    """Gene ranges spanning disjoint segments should be concatenated."""
+    from postalign.models import NAPosition
+    from postalign.utils.group_by_codons import group_by_gene_codons
+
+    ref = NAPosition.init_from_bytes(b"ATGAAATTT")
+    seq = NAPosition.init_from_bytes(b"ATGAAATTT")
+    genes = [("geneA", [(1, 3), (7, 9)])]
+    results = group_by_gene_codons(ref, seq, genes)
+    assert results[0][0] == "geneA"
+    assert [NAPosition.as_str(c) for c in results[0][1]] == ["ATG", "TTT"]
+
+
+def test_find_codon_trim_slice_no_trim() -> None:
+    """When no edge gaps exist, the full slice should be returned."""
+    from postalign.models import NAPosition
+    from postalign.utils.group_by_codons import find_codon_trim_slice
+
+    codons = [
+        NAPosition.init_from_bytes(b"ATG"),
+        NAPosition.init_from_bytes(b"AAA"),
+    ]
+    trim_slice = find_codon_trim_slice(codons)
+    assert trim_slice == slice(0, 2)

--- a/tests/test_iupac.py
+++ b/tests/test_iupac.py
@@ -21,3 +21,17 @@ def test_iupac_score_perfect_match() -> None:
     from postalign.utils.iupac import iupac_score
 
     assert iupac_score(ord(b"A"), ord(b"A")) == 1
+
+
+def test_iupac_score_ambiguous_vs_gap() -> None:
+    """Ambiguous bases against gaps should score as full mismatches."""
+    from postalign.utils.iupac import iupac_score
+
+    assert iupac_score(ord(b"W"), ord(b"-")) == -1
+
+
+def test_iupac_score_ambiguous_mismatch() -> None:
+    """Disjoint ambiguous bases should incur maximal penalty."""
+    from postalign.utils.iupac import iupac_score
+
+    assert iupac_score(ord(b"R"), ord(b"Y")) == -1

--- a/tests/test_iupac.py
+++ b/tests/test_iupac.py
@@ -14,3 +14,10 @@ def test_iupac_score_partial_mismatch() -> None:
     from postalign.utils.iupac import iupac_score
 
     assert iupac_score(ord(b"W"), ord(b"A")) == -0.5
+
+
+def test_iupac_score_perfect_match() -> None:
+    """Identical nucleotides should return a score of one."""
+    from postalign.utils.iupac import iupac_score
+
+    assert iupac_score(ord(b"A"), ord(b"A")) == 1

--- a/tests/test_iupac.py
+++ b/tests/test_iupac.py
@@ -1,38 +1,16 @@
-"""Tests for IUPAC utilities."""
-
-from __future__ import annotations
-
-from typing import Callable, cast
-
-import pytest
+"""Tests for IUPAC nucleotide scoring."""
 
 
-@pytest.fixture()
-def iupac_score_func() -> Callable[[int, int], float]:
-    """Return the :func:`~postalign.utils.iupac.iupac_score` function."""
+def test_iupac_score_gap_match() -> None:
+    """Matching gaps should incur no penalty."""
     from postalign.utils.iupac import iupac_score
 
-    return cast(Callable[[int, int], float], iupac_score)
-
-
-def test_iupac_score_match(
-    iupac_score_func: Callable[[int, int], float]
-) -> None:
-    """Identical nucleotides should score 1."""
-    assert iupac_score_func(ord(b"A"), ord(b"A")) == 1
-
-
-def test_iupac_score_deletion(
-    iupac_score_func: Callable[[int, int], float]
-) -> None:
-    """In-frame deletions should score 0."""
     gap = ord(b"-")
-    assert iupac_score_func(gap, gap) == 0
+    assert iupac_score(gap, gap) == 0
 
 
-def test_iupac_score_ambiguous(
-    iupac_score_func: Callable[[int, int], float]
-) -> None:
-    """Ambiguous mismatch should yield negative fractional score."""
-    score = iupac_score_func(ord(b"W"), ord(b"A"))
-    assert score == -0.5
+def test_iupac_score_partial_mismatch() -> None:
+    """Ambiguous bases should yield a fractional mismatch score."""
+    from postalign.utils.iupac import iupac_score
+
+    assert iupac_score(ord(b"W"), ord(b"A")) == -0.5

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -11,3 +11,11 @@ def test_message_string_and_dict() -> None:
     assert str(message) == "[WARNING] 1:issue"
     assert repr(message) == "<Message [WARNING] 1:issue>"
     assert message.to_dict() == {"level": "WARNING", "message": "issue"}
+
+
+def test_message_level_enum_values() -> None:
+    """Enum members should expose their integer levels."""
+    from postalign.models.message import MessageLevel
+
+    assert MessageLevel.INFO.value == 0
+    assert MessageLevel.ERROR.value == 2

--- a/tests/test_paf.py
+++ b/tests/test_paf.py
@@ -177,6 +177,22 @@ def test_paf_load_inserts_unaligned_region() -> None:
     )
 
 
+def test_paf_load_missing_alignment_yields_empty_sequences() -> None:
+    """Sequences without PAF records should yield empty texts."""
+    from io import StringIO
+
+    from postalign.models import NAPosition, Message
+    from postalign.parsers import paf
+
+    paf_text = "1\t4\t0\t4\t+\tref\t4\t0\t4\t4\t4\t60\tcg:Z:4M\n"
+    seqs = StringIO(">1\nAAAA\n>2\nTTTT\n")
+    ref = StringIO(">ref\nAAAA\n")
+    messages: list[Message] = []
+    pairs = list(paf.load(StringIO(paf_text), seqs, ref, NAPosition, messages))
+    assert pairs[1][0].seqtext_as_str == ""
+    assert pairs[1][1].seqtext_as_str == ""
+
+
 def test_paf_load_skips_reverse_strand() -> None:
     """Reverse-strand alignments should be ignored during loading."""
     from io import StringIO

--- a/tests/test_paf.py
+++ b/tests/test_paf.py
@@ -46,3 +46,316 @@ def test_insert_unaligned_region_inserts_near_alignment2() -> None:
     )
     assert NAPosition.as_str(reftext) == "AB--CD"
     assert NAPosition.as_str(seqtext) == "ABXXCD"
+
+
+def test_insert_unaligned_region_zero_sizes_noop() -> None:
+    """Zero-sized unaligned regions should be ignored."""
+    from postalign.parsers.paf import insert_unaligned_region
+    from postalign.models import NAPosition
+
+    reftext = NAPosition.init_from_bytes(b"AB")
+    seqtext = NAPosition.init_from_bytes(b"AB")
+    orig = seqtext[:]
+    insert_unaligned_region(
+        reftext,
+        seqtext,
+        orig,
+        NAPosition,
+        align1_ref_end=1,
+        align1_seq_end=1,
+        align2_ref_start=1,
+        align2_seq_start=1,
+    )
+    assert NAPosition.as_str(reftext) == "AB"
+    assert NAPosition.as_str(seqtext) == "AB"
+
+
+def test_insert_unaligned_region_defaults_to_alignment2() -> None:
+    """Default placement should favor the second alignment."""
+    from postalign.parsers.paf import insert_unaligned_region
+    from postalign.models import NAPosition
+
+    reftext = NAPosition.init_from_bytes(b"ABCD")
+    seqtext = NAPosition.init_from_bytes(b"ABCD")
+    orig = NAPosition.init_from_bytes(b"ABXXCD")
+    insert_unaligned_region(
+        reftext,
+        seqtext,
+        orig,
+        NAPosition,
+        align1_ref_end=2,
+        align1_seq_end=2,
+        align2_ref_start=4,
+        align2_seq_start=4,
+    )
+    assert NAPosition.as_str(reftext) == "ABCD--"
+    assert NAPosition.as_str(seqtext) == "ABCDXX"
+
+
+def test_insert_unaligned_region_seq_only() -> None:
+    """Reference gaps should be inserted when only sequence extends."""
+    from postalign.parsers.paf import insert_unaligned_region
+    from postalign.models import NAPosition
+
+    reftext = NAPosition.init_from_bytes(b"AB")
+    seqtext = NAPosition.init_from_bytes(b"AB")
+    orig = NAPosition.init_from_bytes(b"AXB")
+    insert_unaligned_region(
+        reftext,
+        seqtext,
+        orig,
+        NAPosition,
+        align1_ref_end=1,
+        align1_seq_end=1,
+        align2_ref_start=1,
+        align2_seq_start=2,
+    )
+    assert NAPosition.as_str(reftext) == "A-B"
+    assert NAPosition.as_str(seqtext) == "AXB"
+
+
+def test_insert_unaligned_region_ref_only_noop() -> None:
+    """Reference-only gaps should leave texts unchanged."""
+    from postalign.parsers.paf import insert_unaligned_region
+    from postalign.models import NAPosition
+
+    reftext = NAPosition.init_from_bytes(b"AB")
+    seqtext = NAPosition.init_from_bytes(b"AB")
+    orig = seqtext[:]
+    insert_unaligned_region(
+        reftext,
+        seqtext,
+        orig,
+        NAPosition,
+        align1_ref_end=1,
+        align1_seq_end=1,
+        align2_ref_start=3,
+        align2_seq_start=1,
+    )
+    assert NAPosition.as_str(reftext) == "AB"
+    assert NAPosition.as_str(seqtext) == "AB"
+
+
+def test_paf_load_no_alignment_returns_error() -> None:
+    """Sequences without matching PAF entries should yield empty texts."""
+    from io import StringIO
+    from unittest.mock import patch
+    import importlib
+    import sys
+    import pafpy  # type: ignore[import-untyped]
+    from postalign.models import NAPosition, Message
+
+    paf_stream = StringIO("")
+    seqs = StringIO(">1\nAC\n")
+    ref = StringIO(">ref\nAC\n")
+    messages: list[Message] = []
+    with patch.dict(sys.modules, {"pafpy": pafpy}):
+        import postalign.parsers.paf as paf_module
+        paf_module = importlib.reload(paf_module)
+        refseq, seq = list(
+            paf_module.load(paf_stream, seqs, ref, NAPosition, messages)
+        )[0]
+        assert refseq.seqtext_as_str == ""
+        assert seq.seqtext_as_str == ""
+        paf_module = importlib.reload(paf_module)
+
+
+def test_paf_load_skips_reverse_strand() -> None:
+    """Reverse-strand alignments should be ignored during loading."""
+    from io import StringIO
+    from types import SimpleNamespace, ModuleType
+    from unittest.mock import patch
+    import importlib
+    import sys
+    from postalign.models import NAPosition, Message
+
+    fake_pafpy = ModuleType("pafpy")
+
+    class FakePafRecord:
+        def __init__(
+            self,
+            qname: str,
+            tstart: int,
+            tend: int,
+            qstart: int,
+            qend: int,
+            strand: str,
+            cigar: str,
+        ) -> None:
+            self.qname = qname
+            self.tstart = tstart
+            self.tend = tend
+            self.qstart = qstart
+            self.qend = qend
+            self.strand = strand
+            self.tags = {"cg": SimpleNamespace(value=cigar)}
+
+        @classmethod
+        def from_str(cls, line: str) -> "FakePafRecord":
+            parts = line.strip().split("\t")
+            return cls(
+                parts[0],
+                int(parts[7]),
+                int(parts[8]),
+                int(parts[2]),
+                int(parts[3]),
+                parts[4],
+                parts[12].split(":")[-1],
+            )
+
+    fake_pafpy.PafRecord = FakePafRecord  # type: ignore[attr-defined]
+    fake_pafpy.Strand = SimpleNamespace(  # type: ignore[attr-defined]
+        Reverse="-"
+    )
+
+    paf_stream = StringIO(
+        "1\t4\t0\t4\t-\tref\t4\t0\t4\t4\t4\t60\tcg:Z:4M\n"
+    )
+    seqs = StringIO(">1\nACGT\n")
+    ref = StringIO(">ref\nACGT\n")
+    messages: list[Message] = []
+    with patch.dict(sys.modules, {"pafpy": fake_pafpy}):
+        import postalign.parsers.paf as paf_module
+        paf_module = importlib.reload(paf_module)
+        refseq, seq = next(
+            iter(paf_module.load(paf_stream, seqs, ref, NAPosition, messages))
+        )
+        assert seq.seqtext_as_str == ""
+        paf_module = importlib.reload(paf_module)
+
+
+def test_paf_load_overlapping_seq_range_warns() -> None:
+    """Overlapping sequence ranges should emit a warning."""
+    from io import StringIO
+    from types import SimpleNamespace, ModuleType
+    from unittest.mock import patch
+    import importlib
+    import sys
+    from postalign.models import NAPosition, Message, MessageLevel
+
+    fake_pafpy = ModuleType("pafpy")
+
+    class FakePafRecord:
+        def __init__(
+            self,
+            qname: str,
+            tstart: int,
+            tend: int,
+            qstart: int,
+            qend: int,
+            strand: str,
+            cigar: str,
+        ) -> None:
+            self.qname = qname
+            self.tstart = tstart
+            self.tend = tend
+            self.qstart = qstart
+            self.qend = qend
+            self.strand = strand
+            self.tags = {"cg": SimpleNamespace(value=cigar)}
+
+        @classmethod
+        def from_str(cls, line: str) -> "FakePafRecord":
+            parts = line.strip().split("\t")
+            return cls(
+                parts[0],
+                int(parts[7]),
+                int(parts[8]),
+                int(parts[2]),
+                int(parts[3]),
+                parts[4],
+                parts[12].split(":")[-1],
+            )
+
+    fake_pafpy.PafRecord = FakePafRecord  # type: ignore[attr-defined]
+    fake_pafpy.Strand = SimpleNamespace(  # type: ignore[attr-defined]
+        Reverse="-"
+    )
+
+    paf_text = (
+        "1\t8\t0\t4\t+\tref\t8\t0\t4\t4\t4\t60\tcg:Z:4M\n"
+        "1\t8\t2\t6\t+\tref\t8\t4\t8\t4\t4\t60\tcg:Z:4M\n"
+    )
+    paf_stream = StringIO(paf_text)
+    seqs = StringIO(">1\nAAAAAAAA\n")
+    ref = StringIO(">ref\nAAAAAAAA\n")
+    messages: list[Message] = []
+    with patch.dict(sys.modules, {"pafpy": fake_pafpy}):
+        import postalign.parsers.paf as paf_module
+        paf_module = importlib.reload(paf_module)
+        list(paf_module.load(paf_stream, seqs, ref, NAPosition, messages))
+        assert any(
+            "SEQ has already been aligned" in m.message for m in messages
+        )
+        assert all(m.level == MessageLevel.WARNING for m in messages)
+        paf_module = importlib.reload(paf_module)
+
+
+def test_paf_load_ref_overlap_shrinks_cigar() -> None:
+    """Reference overlaps should shrink the CIGAR and warn the user."""
+    from io import StringIO
+    from types import SimpleNamespace, ModuleType
+    from unittest.mock import patch
+    import importlib
+    import sys
+    from postalign.models import NAPosition, Message
+
+    fake_pafpy = ModuleType("pafpy")
+
+    class FakePafRecord:
+        def __init__(
+            self,
+            qname: str,
+            tstart: int,
+            tend: int,
+            qstart: int,
+            qend: int,
+            strand: str,
+            cigar: str,
+        ) -> None:
+            self.qname = qname
+            self.tstart = tstart
+            self.tend = tend
+            self.qstart = qstart
+            self.qend = qend
+            self.strand = strand
+            self.tags = {"cg": SimpleNamespace(value=cigar)}
+
+        @classmethod
+        def from_str(cls, line: str) -> "FakePafRecord":
+            parts = line.strip().split("\t")
+            return cls(
+                parts[0],
+                int(parts[7]),
+                int(parts[8]),
+                int(parts[2]),
+                int(parts[3]),
+                parts[4],
+                parts[12].split(":")[-1],
+            )
+
+    fake_pafpy.PafRecord = FakePafRecord  # type: ignore[attr-defined]
+    fake_pafpy.Strand = SimpleNamespace(  # type: ignore[attr-defined]
+        Reverse="-"
+    )
+
+    paf_text = (
+        "1\t8\t0\t4\t+\tref\t8\t0\t4\t4\t4\t60\tcg:Z:4M\n"
+        "1\t8\t4\t8\t+\tref\t8\t2\t6\t4\t4\t60\tcg:Z:4M\n"
+    )
+    paf_stream = StringIO(paf_text)
+    seqs = StringIO(">1\nAAAAAAAA\n")
+    ref = StringIO(">ref\nAAAAAAAA\n")
+    messages: list[Message] = []
+    with patch.dict(sys.modules, {"pafpy": fake_pafpy}):
+        import postalign.parsers.paf as paf_module
+        paf_module = importlib.reload(paf_module)
+        refseq, seq = next(
+            iter(paf_module.load(paf_stream, seqs, ref, NAPosition, messages))
+        )
+        assert any(
+            "REF has already been aligned" in m.message for m in messages
+        )
+        # The first alignment should be shrunk to length 2
+        assert "0,2,2M" in refseq.modifiers.last_modifier.text
+        paf_module = importlib.reload(paf_module)

--- a/tests/test_paf.py
+++ b/tests/test_paf.py
@@ -193,6 +193,24 @@ def test_paf_load_missing_alignment_yields_empty_sequences() -> None:
     assert pairs[1][1].seqtext_as_str == ""
 
 
+def test_paf_load_unknown_sequence_yields_empty_texts() -> None:
+    """Sequences absent from PAF lookup should yield empty pairs."""
+
+    from io import StringIO
+
+    from postalign.models import NAPosition, Message
+    from postalign.parsers import paf
+
+    paf_text = "1\t4\t0\t4\t+\tref\t4\t0\t4\t4\t4\t60\tcg:Z:4M\n"
+    paf_stream = StringIO(paf_text)
+    seqs = StringIO(">2\nTTTT\n")
+    ref = StringIO(">ref\nTTTT\n")
+    messages: list[Message] = []
+    pairs = list(paf.load(paf_stream, seqs, ref, NAPosition, messages))
+    assert pairs[0][0].seqtext_as_str == "TTTT"
+    assert pairs[0][1].seqtext_as_str == "TTTT"
+
+
 def test_paf_load_skips_reverse_strand() -> None:
     """Reverse-strand alignments should be ignored during loading."""
     from io import StringIO

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -95,3 +95,10 @@ def test_msa_load_uses_first_sequence_as_reference() -> None:
     refseq, seq = pairs[0]
     assert refseq.header == "ref"
     assert seq.header == "query"
+
+
+def test_fasta_dump_noop() -> None:
+    """Dumping sequences should complete without error."""
+    from postalign.parsers import fasta
+
+    fasta.dump([], StringIO(), "NA")

--- a/tests/test_save_fasta.py
+++ b/tests/test_save_fasta.py
@@ -51,3 +51,25 @@ def test_save_fasta_preserve_order_skips_ref_for_nonsequential() -> None:
     proc = save_fasta(preserve_order=True)
     output = list(proc([(ref, seq)], []))
     assert output == [">seq\n", "AA\n"]
+
+
+def test_save_fasta_without_modifiers() -> None:
+    """Headers should omit modifiers when the flag is disabled."""
+    from postalign.processors.save_fasta import save_fasta
+
+    ref = _make_seq("ref", 1, b"AA")
+    seq = _make_seq("seq", 2, b"AA")
+    proc = save_fasta(modifiers=False)
+    output = list(proc([(ref, seq)], []))
+    assert output == [">ref\n", "AA\n", ">seq\n", "AA\n"]
+
+
+def test_save_fasta_defaults_include_ref_first() -> None:
+    """Default settings should emit the reference for the first pair."""
+    from postalign.processors.save_fasta import save_fasta
+
+    ref = _make_seq("ref", 1, b"AA")
+    seq = _make_seq("seq", 2, b"AA")
+    proc = save_fasta()
+    output = list(proc([(ref, seq)], []))
+    assert output == [">ref\n", "AA\n", ">seq\n", "AA\n"]

--- a/tests/test_save_json.py
+++ b/tests/test_save_json.py
@@ -48,3 +48,112 @@ def test_gene_range_tuples_callback_refend_too_small() -> None:
     param = MagicMock()
     with pytest.raises(typer.BadParameter):
         gene_range_tuples_callback(ctx, param, ("G", "2", "3"))
+
+
+def test_gene_range_tuples_callback_multiple_ranges() -> None:
+    """Callback should support multiple ranges for a gene."""
+    from postalign.processors.save_json import gene_range_tuples_callback
+
+    ctx = MagicMock()
+    param = MagicMock()
+    result = gene_range_tuples_callback(
+        ctx, param, ("G", "1", "4", "7", "10")
+    )
+    assert result == [("G", [(1, 4), (7, 10)])]
+
+
+def test_gene_range_tuples_callback_two_genes() -> None:
+    """Multiple genes should yield separate tuples."""
+    from postalign.processors.save_json import gene_range_tuples_callback
+
+    ctx = MagicMock()
+    param = MagicMock()
+    result = gene_range_tuples_callback(
+        ctx, param, ("G1", "1", "4", "G2", "5", "8")
+    )
+    assert result == [("G1", [(1, 4)]), ("G2", [(5, 8)])]
+
+
+def test_gene_range_tuples_callback_empty_input() -> None:
+    """Callback should handle an empty argument list."""
+    from postalign.processors.save_json import gene_range_tuples_callback
+
+    ctx = MagicMock()
+    param = MagicMock()
+    assert gene_range_tuples_callback(ctx, param, ()) == []
+
+
+def test_save_json_includes_frameshift() -> None:
+    """Processor output should list frameshift events."""
+    from unittest.mock import patch
+    from postalign.processors.save_json import save_json
+    from postalign.models import Sequence, NAPosition, Message
+
+    refcd = NAPosition.init_from_bytes(b"AAA")
+    seqcd = refcd + [NAPosition.init_from_bytes(b"T")[0]]
+    gene_codons = [("G", [refcd], [seqcd])]
+    with patch(
+        "postalign.processors.save_json.group_by_gene_codons",
+        return_value=gene_codons,
+    ), patch(
+        "postalign.processors.save_json.find_codon_trim_slice",
+        return_value=slice(0, 1),
+    ), patch(
+        "postalign.processors.save_json.translate_codon",
+        return_value=b"M",
+    ):
+        processor = save_json([("G", [(1, 4)])])
+        refseq = Sequence(
+            header=">ref",
+            description="",
+            seqtext=refcd,
+            seqid=1,
+            seqtype=NAPosition,
+            abs_seqstart=0,
+        )
+        seq = Sequence(
+            header=">seq",
+            description="",
+            seqtext=seqcd,
+            seqid=1,
+            seqtype=NAPosition,
+            abs_seqstart=0,
+        )
+        messages: list[Message] = []
+        output = "".join(processor([(refseq, seq)], messages))
+        assert '"FrameShifts":' in output
+
+
+def test_save_json_reports_unaligned_gene() -> None:
+    """Genes without codons should record an error message."""
+    from unittest.mock import patch
+    from postalign.processors.save_json import save_json
+    from postalign.models import Sequence, NAPosition, Message
+
+    with patch(
+        "postalign.processors.save_json.group_by_gene_codons",
+        return_value=[("G", [], [])],
+    ), patch(
+        "postalign.processors.save_json.find_codon_trim_slice",
+        return_value=slice(0, 0),
+    ):
+        processor = save_json([("G", [(1, 4)])])
+        refseq = Sequence(
+            header=">ref",
+            description="",
+            seqtext=[],
+            seqid=1,
+            seqtype=NAPosition,
+            abs_seqstart=0,
+        )
+        seq = Sequence(
+            header=">seq",
+            description="",
+            seqtext=[],
+            seqid=1,
+            seqtype=NAPosition,
+            abs_seqstart=0,
+        )
+        messages: list[Message] = []
+        output = "".join(processor([(refseq, seq)], messages))
+        assert '"Error": "Sequence is not aligned"' in output

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -49,3 +49,10 @@ def test_sequence_getitem_step_slice_error() -> None:
     seq = _make_sequence(b"AT")
     with pytest.raises(ValueError):
         _ = seq[::2]
+
+
+def test_sequence_add_non_sequence_type_error() -> None:
+    """Adding a non-sequence object should raise ``TypeError``."""
+    seq = _make_sequence(b"AT")
+    with pytest.raises(TypeError):
+        _ = seq + 1  # type: ignore[operator]

--- a/tests/test_trim_by_ref.py
+++ b/tests/test_trim_by_ref.py
@@ -53,6 +53,18 @@ def test_trim_by_ref_processor_skips_unaligned() -> None:
     assert seq_out.seqtext == ""
 
 
+def test_trim_by_ref_processor_no_trim_on_gapless_ref() -> None:
+    """Processor leaves sequences unchanged when reference lacks edge gaps."""
+    from postalign.processors.trim_by_ref import trim_by_ref
+
+    ref = _make_seq("ref", b"ACGT", 1)
+    seq = _make_seq("seq", b"AC-T", 2)
+    proc = trim_by_ref()
+    out_ref, out_seq = list(proc([(ref, seq)], []))[0]
+    assert out_ref.seqtext_as_str == "ACGT"
+    assert out_seq.seqtext_as_str == "AC-T"
+
+
 def test_find_trim_slice_no_gaps() -> None:
     """Sequences without leading/trailing gaps yield empty slice."""
     from postalign.processors.trim_by_ref import find_trim_slice

--- a/tests/test_trim_by_ref.py
+++ b/tests/test_trim_by_ref.py
@@ -38,3 +38,24 @@ def test_trim_by_ref_processor_trims() -> None:
     trimmed_ref, trimmed_seq = list(proc([(ref, seq)], []))[0]
     assert trimmed_ref.seqtext_as_str == "ACGT"
     assert trimmed_seq.seqtext_as_str == "AC-T"
+
+
+def test_trim_by_ref_processor_skips_unaligned() -> None:
+    """Unaligned sequences should pass through unchanged."""
+    from postalign.processors.trim_by_ref import trim_by_ref
+
+    ref = _make_seq("ref", b"--ACGT--", 1)
+    seq = _make_seq("seq", b"", 2)
+    seq.seqtext = ""  # type: ignore[assignment]
+    proc = trim_by_ref()
+    ref_out, seq_out = list(proc([(ref, seq)], []))[0]
+    assert ref_out.seqtext_as_str == "--ACGT--"
+    assert seq_out.seqtext == ""
+
+
+def test_find_trim_slice_no_gaps() -> None:
+    """Sequences without leading/trailing gaps yield empty slice."""
+    from postalign.processors.trim_by_ref import find_trim_slice
+
+    ref = _make_seq("ref", b"ACGT", 1)
+    assert find_trim_slice(ref) == slice(None, None)


### PR DESCRIPTION
## Summary
- exercise PAF parser for reverse-strand records, overlapping ranges, and reference shrink behavior
- cover codon grouping utilities for multi-range genes and full-trim cases
- validate IUPAC scoring and JSON exporter frameshift and unaligned gene outputs

## Testing
- `flake8 tests/test_paf.py tests/test_group_by_codons.py tests/test_iupac.py tests/test_save_json.py`
- `mypy .`
- `pytest --cov=postalign --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68993be5096c832486aa02c334487455